### PR TITLE
Add starting Hazelcast cluster template

### DIFF
--- a/modules/ROOT/pages/start-hz-cluster.adoc
+++ b/modules/ROOT/pages/start-hz-cluster.adoc
@@ -1,5 +1,3 @@
-=== Starting Hazelcast Cluster
-
 [tabs]
 ====
 
@@ -15,7 +13,7 @@ Docker Image::
 You can start members inside Docker containers. See the https://github.com/hazelcast/hazelcast-docker[documentation] for details.
 [source, bash]
 ----
-docker run hazelcast/hazelcast:$HAZELCAST_VERSION
+$ docker run hazelcast/hazelcast:$HAZELCAST_VERSION
 ----
 --
 
@@ -35,7 +33,14 @@ Download Packages::
 You can start members via `start` script in https://hazelcast.org/imdg/download[IMDG bundle].
 [source, bash]
 ----
-$ sh bin/start.sh 
+$ sh bin/start.sh
 ----
 --
 ====
+
+[NOTE]
+====
+You can find other ways of starting Hazelcast members and forming a cluster
+https://docs.hazelcast.org/docs/latest/manual/html-single/#installing-hazelcast-imdg[here].
+====
+

--- a/modules/ROOT/pages/start-hz-cluster.adoc
+++ b/modules/ROOT/pages/start-hz-cluster.adoc
@@ -1,0 +1,44 @@
+=== Starting Hazelcast Cluster
+
+[tabs]
+====
+
+Hazelcast Cloud::
++
+--
+You can create a cluster on Hazelcast cloud. Once you get your `discovery token`
+you can use it as a service in you applications via Hazelcast client.
+See https://cloud.hazelcast.com[Hazelcast Cloud] and the https://docs.cloud.hazelcast.com/docs[documentation]
+for details.
+--
+
+Docker Image::
++
+--
+You can start members inside Docker containers. See the https://github.com/hazelcast/hazelcast-docker[documentation] for details.
+[source, bash]
+----
+docker run hazelcast/hazelcast:$HAZELCAST_VERSION
+----
+--
+
+Hazelcast CLI::
++
+--
+You can start members via Hazelcast CLI. See the https://github.com/hazelcast/hazelcast-command-line[documentation] for installation instructions and details.
+[source, bash]
+----
+$ hz start
+----
+--
+
+Download Packages::
++
+--
+You can start members via `start` script in https://hazelcast.org/imdg/download[IMDG bundle].
+[source, bash]
+----
+$ sh bin/start.sh 
+----
+--
+====

--- a/modules/ROOT/pages/start-hz-cluster.adoc
+++ b/modules/ROOT/pages/start-hz-cluster.adoc
@@ -6,10 +6,7 @@
 Hazelcast Cloud::
 +
 --
-You can create a cluster on Hazelcast cloud. Once you get your `discovery token`
-you can use it as a service in your applications via Hazelcast client.
-See https://cloud.hazelcast.com[Hazelcast Cloud] and the https://docs.cloud.hazelcast.com/docs[documentation]
-for details.
+You can easily create a Hazelcast Cluster on https://cloud.hazelcast.com[Hazelcast Cloud] with just a few clicks. See https://docs.cloud.hazelcast.com/docs/getting-started[Getting Started] documentation for details.
 --
 
 Docker Image::

--- a/modules/ROOT/pages/start-hz-cluster.adoc
+++ b/modules/ROOT/pages/start-hz-cluster.adoc
@@ -6,7 +6,7 @@
 Hazelcast Cloud::
 +
 --
-You can easily create a Hazelcast Cluster on https://cloud.hazelcast.com[Hazelcast Cloud] with just a few clicks. See https://docs.cloud.hazelcast.com/docs/getting-started[Getting Started] documentation for details.
+You can easily create a Hazelcast cluster on https://cloud.hazelcast.com[Hazelcast Cloud] with just a few clicks. See https://docs.cloud.hazelcast.com/docs/getting-started[Getting Started] documentation for details.
 --
 
 Docker Image::

--- a/modules/ROOT/pages/start-hz-cluster.adoc
+++ b/modules/ROOT/pages/start-hz-cluster.adoc
@@ -7,7 +7,7 @@ Hazelcast Cloud::
 +
 --
 You can create a cluster on Hazelcast cloud. Once you get your `discovery token`
-you can use it as a service in you applications via Hazelcast client.
+you can use it as a service in your applications via Hazelcast client.
 See https://cloud.hazelcast.com[Hazelcast Cloud] and the https://docs.cloud.hazelcast.com/docs[documentation]
 for details.
 --
@@ -25,7 +25,7 @@ docker run hazelcast/hazelcast:$HAZELCAST_VERSION
 Hazelcast CLI::
 +
 --
-You can start members via Hazelcast CLI. See the https://github.com/hazelcast/hazelcast-command-line[documentation] for installation instructions and details.
+You can start members via Hazelcast CLI. See the https://github.com/hazelcast/hazelcast-command-line[documentation] for the installation instructions and details.
 [source, bash]
 ----
 $ hz start


### PR DESCRIPTION
Related: https://github.com/hazelcast-guides/hazelcast-embedded-microprofile/issues/19

@cangencer @leszko Could you please take a look and let me know if there could be any other option? The template will look like:
![start-cluster](https://user-images.githubusercontent.com/44522401/100231724-786cc380-2f38-11eb-98d7-e4879bbae270.png)
